### PR TITLE
Lower Rails version dependency

### DIFF
--- a/new_google_recaptcha.gemspec
+++ b/new_google_recaptcha.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", ">= 5.0.0"
+  s.add_dependency "rails", ">= 4.2.0"
 
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
Works great for me in Rails 4.x. I would prefer using your gem over my own fork.