### PR TITLE
adding I18n support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,11 @@ test/dummy/node_modules/
 test/dummy/yarn-error.log
 test/dummy/storage/
 test/dummy/tmp/
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln

--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ Include Google Recaptcha v3 JS into your Rails app. In head, right before `</hea
 
 Action where recaptcha action was executed. Actions could be viewed in Admin console. More docs: https://developers.google.com/recaptcha/docs/v3. Action name could be "comments", "checkout", etc. Put any name and check scores in console.
 
+## I18n support
+reCAPTCHA passes one types of error explanation to a linked model. It will use the I18n gem
+to translate the default error message if I18n is available. To customize the messages to your locale,
+add these keys to your I18n backend:
+
+`new_google_recaptcha.errors.verification_human` error message displayed when it is something like a robot, or a suspicious action
+
+Also you can translate API response errors to human friendly by adding translations to the locale (`config/locales/en.yml`):
+
+```Yaml
+en:
+  new_google_recaptcha:
+    errors:
+      verification_human: 'Fail'
+```
+
 ## TODO
 
 - check everything works with turbolinks

--- a/lib/new_google_recaptcha.rb
+++ b/lib/new_google_recaptcha.rb
@@ -11,10 +11,19 @@ module NewGoogleRecaptcha
   def self.human?(token, model = nil)
     is_valid = NewGoogleRecaptcha::Validator.valid?(token)
     if model && !is_valid
-      model.errors.add(:base, "Looks like you are not a human")
+      model.errors.add(:base, self.i18n("new_google_recaptcha.errors.verification_human", "Looks like you are not a human"))
     end
     is_valid
   end
+
+  def self.i18n(key, default)
+    if defined?(I18n)
+      I18n.translate(key, default: default)
+    else
+      default
+    end
+  end
+
 end
 
 require_relative "new_google_recaptcha/view_ext"


### PR DESCRIPTION
Adding I18n support.
Example
```Yaml
#config/locales/pt-BR.yml
pt-BR: 
  new_google_recaptcha:
    errors:
      verification_human: 'Falha na confirmação de reCAPTCHA, tente novamente.'
```
