### PR TITLE
Feature to fetch score

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ vendor/bundle
 *.ntvs*
 *.njsproj
 *.sln
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Google Recaptcha v3 + Rails
 
-Integrate Google Recaptcha v3 with Rails app. 
+Integrate Google Recaptcha v3 with Rails app.
 
 Google Recaptcha console: https://www.google.com/recaptcha/admin#list
 
@@ -45,6 +45,27 @@ Recaptcha v3 documentation: https://developers.google.com/recaptcha/docs/v3
     end
   end
   ```
+  or
+  ```ruby
+  def create
+    @post = Post.new(post_params)
+    humanity_details =
+      NewGoogleRecaptcha.get_humanity_detailed(
+        params[:new_google_recaptcha_token],
+        "checkout",
+        NewGoogleRecaptcha.minimum_score,
+        @post
+      )
+
+    @post.humanity_score = humanity_details[:actual_score]
+
+    if humanity_details[:is_human] && @post.save
+      redirect_to @post, notice: 'Post was successfully created.'
+    else
+      render :new
+    end
+  end
+  ```
 
 There are two mandatory arguments for `human?` method:
 
@@ -66,6 +87,13 @@ like this:
 ```ruby
   NewGoogleRecaptcha.human?(params[:new_google_recaptcha_token], "checkout")
 ```
+
+`get_humanity_detailed` method acts like `human?` method,
+the only difference is that it returns following hash with two key-value pairs:
+- `is_human` - whether actor is a human or not (same as result of `human?` method)
+- `actual_score` - actual humanity score from recaptcha response
+
+It could be handy if you want to store score in db or put it into logs or smth else.
 
 Add to your navigation links `data-turbolinks="false"` to make it works with `turbolinks`.
 
@@ -90,7 +118,7 @@ And edit new_google_recaptcha.rb and enter your site_key and secret_key.
 
 ## API
 
-`NewGoogleRecaptcha.human?(token, model)` in contoller
+`NewGoogleRecaptcha.human?(token, model)` or `NewGoogleRecaptcha.get_humanity_detailed(token, model)` in contoller
 
 - token is received from google, must be sent to backend
 - model optional parameter. if you want to add error to model.

--- a/lib/new_google_recaptcha.rb
+++ b/lib/new_google_recaptcha.rb
@@ -25,6 +25,12 @@ module NewGoogleRecaptcha
     end
   end
 
+  def self.compose_uri(token)
+    URI(
+      "https://www.google.com/recaptcha/api/siteverify?"\
+      "secret=#{self.secret_key}&response=#{token}"
+    )
+  end
 end
 
 require_relative "new_google_recaptcha/view_ext"

--- a/lib/new_google_recaptcha.rb
+++ b/lib/new_google_recaptcha.rb
@@ -10,11 +10,35 @@ module NewGoogleRecaptcha
   end
 
   def self.human?(token, action, minimum_score = self.minimum_score, model = nil)
-    is_valid = NewGoogleRecaptcha::Validator.valid?(token, action, minimum_score)
+    is_valid =
+      NewGoogleRecaptcha::Validator.new(
+        token: token,
+        action: action,
+        minimum_score: minimum_score
+      ).call
+
     if model && !is_valid
       model.errors.add(:base, self.i18n("new_google_recaptcha.errors.verification_human", "Looks like you are not a human"))
     end
+
     is_valid
+  end
+
+  def self.get_humanity_detailed(token, action, minimum_score = self.minimum_score, model = nil)
+    validator =
+      NewGoogleRecaptcha::Validator.new(
+        token: token,
+        action: action,
+        minimum_score: minimum_score
+      )
+
+    is_valid = validator.call
+
+    if model && !is_valid
+      model.errors.add(:base, self.i18n("new_google_recaptcha.errors.verification_human", "Looks like you are not a human"))
+    end
+
+    { is_human: is_valid, actual_score: validator.actual_score }
   end
 
   def self.i18n(key, default)

--- a/lib/new_google_recaptcha/validator.rb
+++ b/lib/new_google_recaptcha/validator.rb
@@ -2,14 +2,24 @@ require 'net/http'
 
 module NewGoogleRecaptcha
   class Validator
-    def self.valid?(token, action, minimum_score)
-      uri    = NewGoogleRecaptcha.compose_uri(token)
+    attr_reader :actual_score
+
+    def initialize(token:, action:, minimum_score:)
+      @token = token
+      @action = action
+      @minimum_score = minimum_score
+    end
+
+    def call
+      uri    = NewGoogleRecaptcha.compose_uri(@token)
       result = JSON.parse(Net::HTTP.get(uri))
+
+      @actual_score = result['score'].to_f
 
       conditions = []
       conditions << !!result['success']
-      conditions << (result['score'].to_f >= minimum_score)
-      conditions << (result['action'].to_s == action.to_s)
+      conditions << (result['score'].to_f >= @minimum_score)
+      conditions << (result['action'].to_s == @action.to_s)
       conditions.none?(&:!)
     end
   end

--- a/lib/new_google_recaptcha/validator.rb
+++ b/lib/new_google_recaptcha/validator.rb
@@ -3,8 +3,9 @@ require 'net/http'
 module NewGoogleRecaptcha
   class Validator
     def self.valid?(token, action, minimum_score)
-      uri    = URI("https://www.google.com/recaptcha/api/siteverify?secret=#{NewGoogleRecaptcha.secret_key}&response=#{token}")
+      uri    = NewGoogleRecaptcha.compose_uri(token)
       result = JSON.parse(Net::HTTP.get(uri))
+
       conditions = []
       conditions << !!result['success']
       conditions << (result['score'].to_f >= minimum_score)

--- a/test/dummy/app/controllers/books_controller.rb
+++ b/test/dummy/app/controllers/books_controller.rb
@@ -1,0 +1,79 @@
+class BooksController < ApplicationController
+  before_action :set_book, only: [:show, :edit, :update, :destroy]
+
+  # GET /books
+  def index
+    @books = Book.all
+  end
+
+  # GET /books/1
+  def show
+  end
+
+  # GET /books/new
+  def new
+    @book = Book.new
+  end
+
+  # GET /books/1/edit
+  def edit
+  end
+
+  # book /books
+  def create
+    @book = Book.new(book_params)
+
+    humanity_datailed =
+      NewGoogleRecaptcha.get_humanity_detailed(
+        params[:new_google_recaptcha_token],
+        'manage_books',
+        NewGoogleRecaptcha.minimum_score,
+        @book
+      )
+
+    @book.humanity_score = humanity_datailed[:actual_score]
+
+    if humanity_datailed[:is_human] && @book.save
+      redirect_to @book, notice: 'Book was successfully created.'
+    else
+      render :new
+    end
+  end
+
+  # PATCH/PUT /books/1
+  def update
+    humanity_datailed =
+      NewGoogleRecaptcha.get_humanity_detailed(
+        params[:new_google_recaptcha_token], 'manage_books'
+      )
+
+    flash[:error] = "Looks like you are not a human" unless humanity_datailed[:is_human]
+
+    if humanity_datailed[:is_human] &&
+      @book.update(params_with_humanity(humanity_datailed[:actual_score]))
+      redirect_to @book, notice: 'Book was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
+  # DELETE /books/1
+  def destroy
+    @book.destroy
+    redirect_to books_url, notice: 'Book was successfully destroyed.'
+  end
+
+  private
+
+  def set_book
+    @book = Book.find(params[:id])
+  end
+
+  def book_params
+    params.require(:book).permit(:author, :title)
+  end
+
+  def params_with_humanity(score)
+    book_params.merge(humanity_score: score)
+  end
+end

--- a/test/dummy/app/models/book.rb
+++ b/test/dummy/app/models/book.rb
@@ -1,0 +1,3 @@
+class Book < ApplicationRecord
+  validates :title, :author, presence: true
+end

--- a/test/dummy/app/views/books/_form.html.erb
+++ b/test/dummy/app/views/books/_form.html.erb
@@ -1,0 +1,29 @@
+<%= form_with(model: book, local: true) do |form| %>
+  <% if book.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(book.errors.count, "error") %> prohibited this book from being saved:</h2>
+
+      <ul>
+      <% book.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :author %>
+    <%= form.text_field :author %>
+  </div>
+
+  <%= recaptcha_action('manage_books') %>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/test/dummy/app/views/books/edit.html.erb
+++ b/test/dummy/app/views/books/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Book</h1>
+
+<%= render 'form', book: @book %>
+
+<%= link_to 'Show', @book %> |
+<%= link_to 'Back', books_path %>

--- a/test/dummy/app/views/books/index.html.erb
+++ b/test/dummy/app/views/books/index.html.erb
@@ -1,0 +1,29 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Books</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Author</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @books.each do |book| %>
+      <tr>
+        <td><%= book.title %></td>
+        <td><%= book.author %></td>
+        <td><%= link_to 'Show', book %></td>
+        <td><%= link_to 'Edit', edit_book_path(book) %></td>
+        <td><%= link_to 'Destroy', book, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Book', new_book_path %>

--- a/test/dummy/app/views/books/new.html.erb
+++ b/test/dummy/app/views/books/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Book</h1>
+
+<%= render 'form', book: @book %>
+
+<%= link_to 'Back', books_path %>

--- a/test/dummy/app/views/books/show.html.erb
+++ b/test/dummy/app/views/books/show.html.erb
@@ -1,0 +1,14 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @book.title %>
+</p>
+
+<p>
+  <strong>Author:</strong>
+  <%= @book.author %>
+</p>
+
+<%= link_to 'Edit', edit_book_path(@book) %> |
+<%= link_to 'Back', books_path %>

--- a/test/dummy/app/views/posts/_form.html.erb
+++ b/test/dummy/app/views/posts/_form.html.erb
@@ -21,7 +21,7 @@
     <%= form.text_area :body %>
   </div>
 
-  <%= recaptcha_action('post') %>
+  <%= recaptcha_action('manage_posts') %>
 
   <div class="actions">
     <%= form.submit %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   resources :posts
+  resources :books
   root to: 'posts#index'
 end

--- a/test/dummy/db/migrate/20190711152953_create_books.rb
+++ b/test/dummy/db/migrate/20190711152953_create_books.rb
@@ -1,0 +1,11 @@
+class CreateBooks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :books do |t|
+      t.string :title
+      t.string :author
+      t.float :humanity_score
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_31_192423) do
+ActiveRecord::Schema.define(version: 2019_07_11_152953) do
+
+  create_table "books", force: :cascade do |t|
+    t.string "title"
+    t.string "author"
+    t.float "humanity_score"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "posts", force: :cascade do |t|
     t.string "title"

--- a/test/dummy/test/controllers/books_controller_test.rb
+++ b/test/dummy/test/controllers/books_controller_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+
+class BooksControllerTest < ActionDispatch::IntegrationTest
+  fixtures :books
+
+  setup do
+    @book = books(:one)
+  end
+
+  test "should create book with recaptcha success and store score in Book" do
+    stub_book_recaptcha_success
+
+    assert_difference('Book.count', 1) do
+      post books_url, params: { book: { author: @book.author, title: @book.title } }
+    end
+
+    assert_redirected_to book_url(Book.last)
+
+    assert_equal(Book.last.humanity_score, 0.9)
+  end
+
+  test "should not create book when failed to pass score level" do
+    stub_book_recaptcha_fail_score
+
+    assert_no_difference('Book.count') do
+      post books_url, params: { book: { author: @book.author, title: @book.title } }
+    end
+
+    assert_includes response.body.to_s, "Looks like you are not a human"
+  end
+
+  test "should not create book when failed to pass action match" do
+    stub_book_recaptcha_fail_action
+
+    assert_no_difference('Book.count') do
+      post books_url, params: { book: { author: @book.author, title: @book.title } }
+    end
+
+    assert_includes response.body.to_s, "Looks like you are not a human"
+  end
+
+  test "should update book with recaptcha success using defaults as arguments" do
+    stub_book_recaptcha_success
+
+    patch book_url(@book), params: { book: { author: @book.author, title: @book.title } }
+
+    assert_redirected_to book_url(@book)
+
+    assert_equal(Book.last.humanity_score, 0.9)
+  end
+
+  test "should not update book with recaptcha when failed to pass score level using defaults as arguments" do
+    stub_book_recaptcha_fail_score
+
+    patch book_url(@book), params: { book: { author: @book.author, title: @book.title } }
+
+    assert_includes response.body.to_s, "Looks like you are not a human"
+  end
+
+  test "should not update book when failed to pass action match using defaults as arguments" do
+    stub_book_recaptcha_fail_action
+
+    patch book_url(@book), params: { book: { author: @book.author, title: @book.title } }
+
+    assert_includes response.body.to_s, "Looks like you are not a human"
+  end
+end

--- a/test/dummy/test/controllers/posts_controller_test.rb
+++ b/test/dummy/test/controllers/posts_controller_test.rb
@@ -8,7 +8,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should create post with recaptcha success" do
-    stub_recaptcha_success
+    stub_post_recaptcha_success
 
     assert_difference('Post.count', 1) do
       post posts_url, params: { post: { body: @post.body, title: @post.title } }
@@ -18,7 +18,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should not create post when failed to pass score level" do
-    stub_recaptcha_fail_score
+    stub_post_recaptcha_fail_score
 
     assert_no_difference('Post.count') do
       post posts_url, params: { post: { body: @post.body, title: @post.title } }
@@ -28,7 +28,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should not create post when failed to pass action match" do
-    stub_recaptcha_fail_action
+    stub_post_recaptcha_fail_action
 
     assert_no_difference('Post.count') do
       post posts_url, params: { post: { body: @post.body, title: @post.title } }
@@ -38,21 +38,21 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update post with recaptcha success using defaults as arguments" do
-    stub_recaptcha_success
+    stub_post_recaptcha_success
 
     patch post_url(@post), params: { post: { body: @post.body, title: @post.title } }
     assert_redirected_to post_url(@post)
   end
 
   test "should not update post with recaptcha when failed to pass score level using defaults as arguments" do
-    stub_recaptcha_fail_score
+    stub_post_recaptcha_fail_score
 
     patch post_url(@post), params: { post: { body: @post.body, title: @post.title } }
     assert_includes response.body.to_s, "Looks like you are not a human"
   end
 
   test "should not update post when failed to pass action match using defaults as arguments" do
-    stub_recaptcha_fail_action
+    stub_post_recaptcha_fail_action
 
     patch post_url(@post), params: { post: { body: @post.body, title: @post.title } }
     assert_includes response.body.to_s, "Looks like you are not a human"

--- a/test/fixtures/books.yml
+++ b/test/fixtures/books.yml
@@ -1,0 +1,7 @@
+one:
+  title: Lord of The Rings
+  author: J.R.R.Tolkien
+
+two:
+  title: The Hitchhiker's Guide to the Galaxy
+  author: Douglas Adams

--- a/test/support/recaptcha_stubs.rb
+++ b/test/support/recaptcha_stubs.rb
@@ -1,4 +1,4 @@
-def stub_recaptcha_success
+def stub_post_recaptcha_success
   stub_request(
       :get,
       "https://www.google.com/recaptcha/api/siteverify?secret=#{NewGoogleRecaptcha.secret_key}&response="
@@ -15,7 +15,7 @@ def stub_recaptcha_success
   )
 end
 
-def stub_recaptcha_fail_score
+def stub_post_recaptcha_fail_score
   stub_request(
       :get,
       "https://www.google.com/recaptcha/api/siteverify?secret=#{NewGoogleRecaptcha.secret_key}&response="
@@ -32,7 +32,58 @@ def stub_recaptcha_fail_score
   )
 end
 
-def stub_recaptcha_fail_action
+def stub_post_recaptcha_fail_action
+  stub_request(
+      :get,
+      "https://www.google.com/recaptcha/api/siteverify?secret=#{NewGoogleRecaptcha.secret_key}&response="
+  ).to_return(
+      status: 200,
+      body: {
+          "success": false,
+          "challenge_ts": "2018-12-31T15:36:25Z",
+          "hostname": "localhost",
+          "score": 0.9,
+          "action": ""
+      }.to_json,
+      headers: {}
+  )
+end
+
+def stub_book_recaptcha_success
+  stub_request(
+      :get,
+      "https://www.google.com/recaptcha/api/siteverify?secret=#{NewGoogleRecaptcha.secret_key}&response="
+  ).to_return(
+      status: 200,
+      body: {
+          "success": true,
+          "challenge_ts": "2018-12-31T15:36:25Z",
+          "hostname": "localhost",
+          "score": 0.9,
+          "action": "manage_books"
+      }.to_json,
+      headers: {}
+  )
+end
+
+def stub_book_recaptcha_fail_score
+  stub_request(
+      :get,
+      "https://www.google.com/recaptcha/api/siteverify?secret=#{NewGoogleRecaptcha.secret_key}&response="
+  ).to_return(
+      status: 200,
+      body: {
+          "success": false,
+          "challenge_ts": "2018-12-31T15:36:25Z",
+          "hostname": "localhost",
+          "score": 0.0,
+          "action": "manage_books"
+      }.to_json,
+      headers: {}
+  )
+end
+
+def stub_book_recaptcha_fail_action
   stub_request(
       :get,
       "https://www.google.com/recaptcha/api/siteverify?secret=#{NewGoogleRecaptcha.secret_key}&response="


### PR DESCRIPTION
Add possibility to get score
It could be handy if someone wants to store it in db or put into logs as me

I did not want to change the structure of `NewGoogleRecaptcha` module and implemented just one additional new method: `NewGoogleRecaptcha.get_humanity_detailed`

It acts like `human?` method, but returns a hash with 2 key-value pairs (e.g.`{ is_human: true, actual_score: 0.9 }` or `{ is_human: false, actual_score: 0.2 }`)