### PR TITLE
Proxy support

### DIFF
--- a/lib/new_google_recaptcha/validator.rb
+++ b/lib/new_google_recaptcha/validator.rb
@@ -13,7 +13,10 @@ module NewGoogleRecaptcha
 
     def call
       uri    = NewGoogleRecaptcha.compose_uri(token)
-      result = JSON.parse(Net::HTTP.get(uri))
+      
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true if uri.scheme == 'https' 
+      result = JSON.parse(http.request(Net::HTTP::Get.new(uri)).body)
 
       @score = result['score'].to_f
 


### PR DESCRIPTION
In our environments, outbound network traffic is restricted by forcing everything through a proxy. Net::HTTP.get doesn't use a proxy, only invoking via Net::HTTP.new does. This change invokes via Net::HTTP.new

https://www.jethrocarr.com/2014/08/14/ruby-nethttp-proxies/