### PR TITLE
Defer recaptchaJS to improve performance

### DIFF
--- a/lib/new_google_recaptcha/view_ext.rb
+++ b/lib/new_google_recaptcha/view_ext.rb
@@ -3,23 +3,39 @@ module NewGoogleRecaptcha
     include ActionView::Helpers::TagHelper
 
     def include_recaptcha_js
-      raw %Q{
-        <script src="https://www.google.com/recaptcha/api.js?render=#{NewGoogleRecaptcha.site_key}"></script>
-      }
+      generate_recaptcha_callback + javascript_include_tag("https://www.google.com/recaptcha/api.js?render=#{NewGoogleRecaptcha.site_key}&onload=newGoogleRecaptchaCallback", defer: true)
     end
 
     def recaptcha_action(action)
       id = "new_google_recaptcha_token_#{SecureRandom.hex(10)}"
-      raw %Q{
-        <input name="new_google_recaptcha_token" type="hidden" id="#{id}"/>
-        <script>
-          grecaptcha.ready(function() {
-            grecaptcha.execute("#{NewGoogleRecaptcha.site_key}", {action: "#{action}"}).then(function(token) {
-              document.getElementById("#{id}").value = token;
-            });
-          });
-        </script>
-      }
+      hidden_field_tag(
+        'new_recaptcha_token',
+        nil,
+        readonly: true,
+        'data-google-recaptcha-action' => action,
+        id: id
+      )
+    end
+
+    private
+
+    def generate_recaptcha_callback
+      javascript_tag %(
+        function newGoogleRecaptchaCallback () {
+          grecaptcha.ready(function () {
+            var elements = document.querySelectorAll('[data-google-recaptcha-action]')
+            Array.prototype.slice.call(elements).forEach(function (el) {
+              var action = el.dataset.googleRecaptchaAction
+              if (!action) return
+              grecaptcha
+                .execute("#{NewGoogleRecaptcha.site_key}", { action: action })
+                .then(function (token) {
+                  el.value = token
+                })
+            })
+          })
+        }
+      )
     end
   end
 end


### PR DESCRIPTION
- Defer recaptchaJS library
- Use tag helper to create `script` tag

Since we had performance issue by loading the google reCAPTCHA js library synchronously, it will block the DOM parsing process which is not good for user experience.

Add [defer](https://flaviocopes.com/javascript-async-defer/) attribute on recaptcha `script` tag, meanwhile add `onload=newGoogleRecaptchaCallback ` parameter into the recaptcha url, the `newGoogleRecaptchaCallback` will be called once recaptchaJS is loaded.

The `newGoogleRecaptchaCallback` will handle all the recaptcha `input`s instead of inserting multiple `script` tags below the `input`.