### PR TITLE
Add badge option

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,17 @@ en:
       verification_human: 'Fail'
 ```
 
+## Badge position
+
+NewGoogleRecaptcha allows you to render badge in different positions
+
+```ruby
+    <%= include_recaptcha_js badge: "bottomleft" %>
+```
+
+Three of existing `badge` values are `bottomright`, `bottomleft` and `inline`.
+'inline' lets you position it with CSS. 
+
 ## TODO
 
 - check everything works with turbolinks

--- a/lib/new_google_recaptcha/view_ext.rb
+++ b/lib/new_google_recaptcha/view_ext.rb
@@ -2,8 +2,13 @@ module NewGoogleRecaptcha
   module ViewExt
     include ActionView::Helpers::TagHelper
 
-    def include_recaptcha_js
-      generate_recaptcha_callback + javascript_include_tag("https://www.google.com/recaptcha/api.js?render=#{NewGoogleRecaptcha.site_key}&onload=newGoogleRecaptchaCallback", defer: true)
+    def include_recaptcha_js(opts = {})
+      badge = opts[:badge] ? "&badge=#{opts[:badge]}" : ""
+      generate_recaptcha_callback +
+        javascript_include_tag(
+          "https://www.google.com/recaptcha/api.js?render=#{NewGoogleRecaptcha.site_key}&onload=newGoogleRecaptchaCallback#{badge}",
+          defer: true
+        )
     end
 
     def recaptcha_action(action)


### PR DESCRIPTION
Officially reCaptcha supports setting badge position to `inline` `bottomleft` or `bottomright` which is the default. This PR adds ability to pass prop `include_recaptcha_js` and reposition a badge.

More at [https://developers.google.com/recaptcha/docs/v3](https://developers.google.com/recaptcha/docs/v3)