### PR TITLE
Update view_ext.rb

### DIFF
--- a/lib/new_google_recaptcha/view_ext.rb
+++ b/lib/new_google_recaptcha/view_ext.rb
@@ -14,7 +14,7 @@ module NewGoogleRecaptcha
     def recaptcha_action(action)
       id = "new_google_recaptcha_token_#{SecureRandom.hex(10)}"
       hidden_field_tag(
-        'new_recaptcha_token',
+        'new_google_recaptcha_token',
         nil,
         readonly: true,
         'data-google-recaptcha-action' => action,


### PR DESCRIPTION
Change new_recaptcha_token to new_google_recaptcha_token, this was trigger an error when the param params[:new_google_recaptcha_token] is not found, some times shows as new_google_recaptcha_token and others as new_recaptcha_token.