### PR TITLE
Fix param name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Recaptcha v3 documentation: https://developers.google.com/recaptcha/docs/v3
   def create
     @post = Post.new(post_params)
     if NewGoogleRecaptcha.human?(
-        params[:new_google_recaptcha_token],
+        params[:new_recaptcha_token],
         "checkout",
         NewGoogleRecaptcha.minimum_score,
         @post
@@ -59,7 +59,7 @@ Recaptcha v3 documentation: https://developers.google.com/recaptcha/docs/v3
     @post = Post.new(post_params)
     humanity_details =
       NewGoogleRecaptcha.get_humanity_detailed(
-        params[:new_google_recaptcha_token],
+        params[:new_recaptcha_token],
         "checkout",
         NewGoogleRecaptcha.minimum_score,
         @post
@@ -93,7 +93,7 @@ You can verify recaptcha without using these arguments:
 like this:
 
 ```ruby
-  NewGoogleRecaptcha.human?(params[:new_google_recaptcha_token], "checkout")
+  NewGoogleRecaptcha.human?(params[:new_recaptcha_token], "checkout")
 ```
 
 ### Saving humanity score from Google in your model
@@ -153,7 +153,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     build_resource(sign_up_params)
 
     NewGoogleRecaptcha.human?(
-      params[:new_google_recaptcha_token],
+      params[:new_recaptcha_token],
       "user",
       NewGoogleRecaptcha.minimum_score,
       resource) && resource.save


### PR DESCRIPTION
in the helper it generates a field callen `new_recaptcha_token`, doc says `new_google_recaptcha_token` which prevents the plugin from working when following the readme